### PR TITLE
Change env variable to its previous name

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ machine:
 dependencies:
   pre:
     - docker login -e none@none.com -u $UW_DOCKER_USERNAME
-      -p $UW_DOCKER_PASSWORD $UW_DOCKER_REGISTRY
+      -p $UW_DOCKER_PASS $UW_DOCKER_REGISTRY
   override:
     #- docker-compose up -d
     #- sleep 5


### PR DESCRIPTION
It is used across many projects as `UW_DOCKER_PASS` and when we import env variables in CircleCI from another project, it can't find `UW_DOCKER_PASSWORD`.

/cc @charlie 