### PR TITLE
Delete binary before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean:
 	rm -f $(SERVICE)
 
 # builds our binary
-$(SERVICE):
+$(SERVICE): clean
 	$(BUILDENV) go build -o $(SERVICE) -a -ldflags '$(LINKFLAGS)' ./cmd/$(SERVICE)
 
 build: $(SERVICE)


### PR DESCRIPTION
If the binary already exists, you get a message saying: `make: Nothing to be done for 'build'.`.