### PR TITLE
adds exec to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ ENV APP=${SERVICE}
 RUN apk add --no-cache ca-certificates && mkdir /app
 COPY --from=build /${SERVICE} /app/${SERVICE}
 
-ENTRYPOINT /app/${APP}
+ENTRYPOINT exec /app/${APP}


### PR DESCRIPTION
this ensures that the service will indeed be PID 1 in the container,
which is important for it to receive the SIGTERM and SIGKILL signals
from the docker daemon. without this, there is two commands running in
the container (/bin/sh -c "/app/$app" and /app/$app), which means that
the go executable won't be getting signals. you can confirm the two
processes by running `docker top <container-name>`.