### PR TITLE
return correct exit status of install failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash -o pipefail
+
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 base_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 


### PR DESCRIPTION
The pipe to sed in the install target results in an incorrect exit
status when `go get` fails. Setting shell with `-o pipefail` fixes the
problem and results in the correct exit status.